### PR TITLE
Lab01 - Update repo cloning instructions

### DIFF
--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -59,6 +59,7 @@ First, copy the link to your repo, like you would when cloning it.
 Then, run the following commands:
 
 ```
+cd lab01_jgaucho_alily
 git remote remove origin
 git remote add origin git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
 git push origin main
@@ -66,13 +67,13 @@ git push origin main
 
 ## Step 1e:
 
-Your partner should now be able to clone your repo:
+Your **partner** should now be able to clone your repo:
 
 ```
 git clone git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
 ```
 
-Typing `ls` should show you the following files in your repo:
+Typing `ls` should show the following files in your repo:
 
 ```
 $ ls

--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -52,7 +52,9 @@ mv STARTER-lab01 lab01_jgaucho_alily
 
 ## Step 1d: 
 
-We're going to do some git magic. If you don't know what's going on in this step, that's fine! However, if you're curious to know, please look up these commands or ask a TA/ULA!
+We're going to do some git magic. 
+
+*Note: If you don't know what's going on in this step, that's fine!*
 
 First, copy the link to your repo, like you would when cloning it.
 
@@ -64,6 +66,8 @@ git remote remove origin
 git remote add origin git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
 git push origin main
 ```
+
+*Note: Replace jgaucho and alily with your and your partner's usernames!*
 
 ## Step 1e:
 

--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -77,6 +77,8 @@ Your **partner** should now be able to clone your repo:
 git clone git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
 ```
 
+*Note: Replace jgaucho and alily with your and your partner's usernames!*
+
 Typing `ls` should show the following files in your repo:
 
 ```

--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -22,21 +22,57 @@ We request that you DO NOT ask the staff to debug your code for you. They have b
 
 # Step by Step Instructions
 
-## Step 1: Getting Ready
+*Note: Designate one partner to do steps 1a-d.*
 
-Create a repo for this lab in our class organization and clone it to your local machine.
+## Step 1a: Create a new repo
 
+Create a repo for this lab in our class organization.
 
-## Step 2: Obtain the starter code
+* Follow step 1b from lab00, but **do not clone the repo yet.**
+
+## Step 1b: Clone the starter code repo
 
 The starter code is in this repo:
 
 * <https://github.com/ucsb-cs24-s22/STARTER-lab01>
 
-The URL for cloning this repo is this: `git@github.com:ucsb-cs24-s22/STARTER-lab01.git`
+To clone it, run
 
+```
+git clone git@github.com:ucsb-cs24-s22/STARTER-lab01.git
+```
 
-Once you've cloned the started code repo, typing the `ls` command on your machine should show you the following files in your current directory
+## Step 1c: Rename your starter code repo
+
+```
+mv STARTER-lab01 lab01_jgaucho_alily
+```
+
+*Note: Replace jgaucho and alily with your and your partner's usernames!*
+
+## Step 1d: 
+
+We're going to do some git magic. If you don't know what's going on in this step, that's fine! However, if you're curious to know, please look up these commands or ask a TA/ULA!
+
+First, copy the link to your repo, like you would when cloning it.
+
+Then, run the following commands:
+
+```
+git remote remove origin
+git remote add origin git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
+git push origin main
+```
+
+## Step 1e:
+
+Your partner should now be able to clone your repo:
+
+```
+git clone git@github.com:ucsb-cs24-s22/lab01_jgaucho_alily.git
+```
+
+Typing `ls` should show you the following files in your repo:
 
 ```
 $ ls

--- a/_lab/lab01.md
+++ b/_lab/lab01.md
@@ -50,7 +50,7 @@ mv STARTER-lab01 lab01_jgaucho_alily
 
 *Note: Replace jgaucho and alily with your and your partner's usernames!*
 
-## Step 1d: 
+## Step 1d: Update your repo's origin
 
 We're going to do some git magic. 
 
@@ -69,7 +69,7 @@ git push origin main
 
 *Note: Replace jgaucho and alily with your and your partner's usernames!*
 
-## Step 1e:
+## Step 1e: Test your git setup
 
 Your **partner** should now be able to clone your repo:
 


### PR DESCRIPTION
# Description
I'm writing this PR per @tshiUCSB's request. Many students got confused because they were either
* trying to push to the starter code repo, 
* cloned their repo inside the starter code repo, or
* cloned the starter code repo inside their repo. 

In addition, some instructions from CS16 meant for this situation didn't work.

This diff updates the cloning instructions to hopefully make it more seamless. 

# Testing
I tested this on a pair of students.

# Acceptance Criteria
- [ ] @dibamirza  or @tshiUCSB  can successfully reproduce step 1.
